### PR TITLE
Add per-user favorites, video filters, and owner controls

### DIFF
--- a/backend/src/controllers/recipes.controller.js
+++ b/backend/src/controllers/recipes.controller.js
@@ -1,95 +1,30 @@
+import {
+  createRecipe,
+  deleteRecipe,
+  getMyRecipes,
+  getRecipes,
+  setFavorite,
+  updateRecipe,
+} from "../services/recipes.service.js";
 
-import { recipeModel } from "../models/recipe.model.js";
-import { userModel } from "../models/user.model.js";
-import mongoose from "mongoose";
-
-const parseBoolean = (value) => {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true") return true;
-    if (normalized === "false") return false;
+const handleServiceError = (res, error, label) => {
+  if (error?.status) {
+    return res.status(error.status).json({ message: error.message });
   }
-  return undefined;
-};
-
-const parseNumber = (value) => {
-  if (value === "" || value === null || value === undefined) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-};
-
-const normalizeDifficulty = (value) => {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim().toLowerCase();
-  return normalized ? normalized : undefined;
-};
-
-const buildFavoriteSet = async (userId) => {
-  if (!userId) return null;
-  if (!mongoose.isValidObjectId(userId)) {
-    const error = new Error("Invalid user id");
-    error.status = 400;
-    throw error;
-  }
-  const user = await userModel.findById(userId).select("favorites").lean();
-  if (!user) {
-    const error = new Error("User not found");
-    error.status = 404;
-    throw error;
-  }
-  return new Set((user.favorites || []).map((id) => String(id)));
-};
-
-const applyFavoriteFlag = (items, favoriteSet) => {
-  if (!favoriteSet) return items;
-  return items.map((item) => ({
-    ...item,
-    fav: favoriteSet.has(String(item._id)),
-  }));
+  console.error(label, error);
+  return res.status(500).json({ message: "Internal server error" });
 };
 
 export async function getRecipesController(req, res) {
   try {
-    const limit = Math.max(1, parseInt(req.query.limit, 10) || 6);
-    const after = req.query.after || null; // last-seen _id (string) or null
-    const userId = req.query.userId || null;
-    const favoriteSet = await buildFavoriteSet(userId);
-
-    // build query
-    const query = {};
-    if (after) {
-      // validate cursor
-      if (!mongoose.isValidObjectId(after)) {
-        return res.status(400).json({ message: "Invalid cursor (after)" });
-      }
-      // descending order: newer -> older, so fetch _id < after
-      query._id = { $lt:new mongoose.Types.ObjectId(after) };
-    }
-
-    // fetch limit+1 to determine hasMore
-    const docs = await recipeModel
-      .find(query)
-      .populate("createdBy", "username avatar")
-      .sort({ _id: -1 }) // newest first (stable)
-      .limit(limit + 1)
-      .lean();
-
-    const hasMore = docs.length > limit;
-    const items = hasMore ? docs.slice(0, limit) : docs;
-    const withFavorites = applyFavoriteFlag(items, favoriteSet);
-
-    return res.json({
-      recipes: withFavorites,
-      hasMore,
-      nextCursor: items.length ? String(items[items.length - 1]._id) : null,
+    const result = await getRecipes({
+      limit: req.query.limit,
+      after: req.query.after || null,
+      userId: req.query.userId || null,
     });
+    return res.json(result);
   } catch (error) {
-    if (error?.status) {
-      return res.status(error.status).json({ message: error.message });
-    }
-    console.error("getRecipesController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "getRecipesController error:");
   }
 }
 
@@ -98,42 +33,11 @@ export async function getRecipesController(req, res) {
  */
 export async function createRecipeController(req, res) {
   try {
-    const userId = req.body.userId;
-    if (!mongoose.isValidObjectId(userId)) {
-      return res.status(400).json({ message: "Invalid user id" });
-    }
-    const recipePayload = req.body.recipe || {};
-    const {
-      title,
-      imageUrl,
-      description,
-      ingredients,
-      instructions,
-      videoUrl,
-      time,
-      difficulty,
-      isVeg,
-      isTrending,
-    } = recipePayload;
-
-    const newRecipe = await recipeModel.create({
-      title,
-      imageUrl,
-      description,
-      ingredients,
-      instructions,
-      videoUrl,
-      time: parseNumber(time),
-      difficulty: normalizeDifficulty(difficulty),
-      isVeg: parseBoolean(isVeg),
-      isTrending: parseBoolean(isTrending),
-      createdBy: userId,
-    });
-
-    return res.status(201).json({ recipe: newRecipe, userId });
+    const userId = req.userId || req.body.userId;
+    const recipe = await createRecipe({ userId, recipe: req.body.recipe });
+    return res.status(201).json({ recipe, userId });
   } catch (error) {
-    console.error("createRecipeController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "createRecipeController error:");
   }
 }
 
@@ -142,189 +46,52 @@ export async function createRecipeController(req, res) {
  */
 export async function deleteRecipeController(req, res) {
   try {
-    const id = req.params.id;
-    if (!mongoose.isValidObjectId(id)) {
-      return res.status(400).json({ message: "Invalid id" });
-    }
-
-    const userId = req.body?.userId || req.query?.userId;
-    if (!mongoose.isValidObjectId(userId)) {
-      return res.status(400).json({ message: "Invalid user id" });
-    }
-
-    const recipe = await recipeModel.findById(id);
-    if (!recipe) {
-      return res.status(404).json({ message: "Recipe not found" });
-    }
-    if (String(recipe.createdBy) !== String(userId)) {
-      return res.status(403).json({ message: "Not allowed to delete this recipe" });
-    }
-
-    await recipe.deleteOne();
+    await deleteRecipe({
+      recipeId: req.params.id,
+      userId: req.userId || req.body?.userId || req.query?.userId,
+    });
     return res.status(200).json({ message: "Recipe deleted successfully" });
   } catch (error) {
-    console.error("deleteRecipeController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "deleteRecipeController error:");
   }
 }
 
 export async function updateRecipeController(req, res) {
   try {
-    const { id } = req.params;
-    if (!mongoose.isValidObjectId(id)) {
-      return res.status(400).json({ message: "Invalid id" });
-    }
-
-    const userId = req.body?.userId;
-    if (!mongoose.isValidObjectId(userId)) {
-      return res.status(400).json({ message: "Invalid user id" });
-    }
-
-    const recipe = await recipeModel.findById(id);
-    if (!recipe) {
-      return res.status(404).json({ message: "Recipe not found" });
-    }
-    if (String(recipe.createdBy) !== String(userId)) {
-      return res.status(403).json({ message: "Not allowed to update this recipe" });
-    }
-
-    const allowedFields = [
-      "title",
-      "imageUrl",
-      "description",
-      "ingredients",
-      "instructions",
-      "videoUrl",
-      "time",
-      "difficulty",
-      "isVeg",
-      "isTrending",
-    ];
-
-    const updates = {};
-    for (const field of allowedFields) {
-      const value = req.body?.[field];
-      if (value !== "" && value !== null && value !== undefined) {
-        updates[field] = value;
-      }
-    }
-
-    if (updates.time !== undefined) {
-      const parsedTime = parseNumber(updates.time);
-      if (parsedTime === undefined) {
-        delete updates.time;
-      } else {
-        updates.time = parsedTime;
-      }
-    }
-
-    if (updates.difficulty !== undefined) {
-      const normalizedDifficulty = normalizeDifficulty(updates.difficulty);
-      if (!normalizedDifficulty) {
-        delete updates.difficulty;
-      } else {
-        updates.difficulty = normalizedDifficulty;
-      }
-    }
-
-    if (updates.isVeg !== undefined) {
-      const parsedIsVeg = parseBoolean(updates.isVeg);
-      if (parsedIsVeg === undefined) {
-        delete updates.isVeg;
-      } else {
-        updates.isVeg = parsedIsVeg;
-      }
-    }
-
-    if (updates.isTrending !== undefined) {
-      const parsedIsTrending = parseBoolean(updates.isTrending);
-      if (parsedIsTrending === undefined) {
-        delete updates.isTrending;
-      } else {
-        updates.isTrending = parsedIsTrending;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return res.status(400).json({ message: "No valid fields to update" });
-    }
-
-    const updatedRecipe = await recipeModel.findByIdAndUpdate(
-      id,
-      { $set: updates },
-      { new: true, runValidators: true }
-    );
-    return res
-      .status(200)
-      .json({ message: "Recipe updated successfully", recipe: updatedRecipe });
+    const updatedRecipe = await updateRecipe({
+      id: req.params.id,
+      userId: req.userId || req.body?.userId,
+      data: req.body,
+    });
+    return res.status(200).json({
+      message: "Recipe updated successfully",
+      recipe: updatedRecipe,
+    });
   } catch (error) {
-    console.error("updateRecipeController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "updateRecipeController error:");
   }
 }
 
 
 export async function getMyRecipesController(req, res) {
   try {
-    const userId = req.params.id;
-    const favoriteSet = await buildFavoriteSet(userId);
-    const myRecipe = await recipeModel
-      .find({ createdBy: userId })
-      .sort({ createdAt: -1 })
-      .lean();
-    const withFavorites = applyFavoriteFlag(myRecipe, favoriteSet);
-    res.status(200).json({ myRecipe: withFavorites });
-
-     
+    const myRecipe = await getMyRecipes({ userId: req.params.id });
+    res.status(200).json({ myRecipe });
   } catch (error) {
-    if (error?.status) {
-      return res.status(error.status).json({ message: error.message });
-    }
-    console.error("getRecipesController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "getMyRecipesController error:");
   }
 }
 
 export async function setFavoriteController(req, res) {
   try {
-    const recipeId = req.params.id;
-    const userId = req.body?.userId;
-    const favorite =
-      typeof req.body?.favorite === "boolean"
-        ? req.body.favorite
-        : typeof req.body?.fav === "boolean"
-          ? req.body.fav
-          : undefined;
-
-    if (!mongoose.isValidObjectId(recipeId)) {
-      return res.status(400).json({ message: "Invalid recipe id" });
-    }
-    if (!mongoose.isValidObjectId(userId)) {
-      return res.status(400).json({ message: "Invalid user id" });
-    }
-    if (favorite === undefined) {
-      return res.status(400).json({ message: "Favorite flag is required" });
-    }
-
-    const [user, recipe] = await Promise.all([
-      userModel.findById(userId).select("_id favorites"),
-      recipeModel.findById(recipeId).select("_id"),
-    ]);
-    if (!user) {
-      return res.status(404).json({ message: "User not found" });
-    }
-    if (!recipe) {
-      return res.status(404).json({ message: "Recipe not found" });
-    }
-
-    const update = favorite
-      ? { $addToSet: { favorites: recipe._id } }
-      : { $pull: { favorites: recipe._id } };
-    await userModel.updateOne({ _id: userId }, update);
-
-    return res.status(200).json({ favorite });
+    const result = await setFavorite({
+      recipeId: req.params.id,
+      userId: req.userId || req.body?.userId,
+      favorite: req.body?.favorite,
+      fav: req.body?.fav,
+    });
+    return res.status(200).json({ favorite: result.favorite });
   } catch (error) {
-    console.error("setFavoriteController error:", error);
-    return res.status(500).json({ message: "Internal server error" });
+    return handleServiceError(res, error, "setFavoriteController error:");
   }
 }

--- a/backend/src/controllers/recipes.controller.js
+++ b/backend/src/controllers/recipes.controller.js
@@ -1,11 +1,60 @@
 
 import { recipeModel } from "../models/recipe.model.js";
+import { userModel } from "../models/user.model.js";
 import mongoose from "mongoose";
+
+const parseBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return undefined;
+};
+
+const parseNumber = (value) => {
+  if (value === "" || value === null || value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const normalizeDifficulty = (value) => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized ? normalized : undefined;
+};
+
+const buildFavoriteSet = async (userId) => {
+  if (!userId) return null;
+  if (!mongoose.isValidObjectId(userId)) {
+    const error = new Error("Invalid user id");
+    error.status = 400;
+    throw error;
+  }
+  const user = await userModel.findById(userId).select("favorites").lean();
+  if (!user) {
+    const error = new Error("User not found");
+    error.status = 404;
+    throw error;
+  }
+  return new Set((user.favorites || []).map((id) => String(id)));
+};
+
+const applyFavoriteFlag = (items, favoriteSet) => {
+  if (!favoriteSet) return items;
+  return items.map((item) => ({
+    ...item,
+    fav: favoriteSet.has(String(item._id)),
+  }));
+};
 
 export async function getRecipesController(req, res) {
   try {
     const limit = Math.max(1, parseInt(req.query.limit, 10) || 6);
     const after = req.query.after || null; // last-seen _id (string) or null
+    const userId = req.query.userId || null;
+    const favoriteSet = await buildFavoriteSet(userId);
 
     // build query
     const query = {};
@@ -20,20 +69,25 @@ export async function getRecipesController(req, res) {
 
     // fetch limit+1 to determine hasMore
     const docs = await recipeModel
-      .find(query).populate('createdBy','username')
+      .find(query)
+      .populate("createdBy", "username avatar")
       .sort({ _id: -1 }) // newest first (stable)
       .limit(limit + 1)
       .lean();
 
     const hasMore = docs.length > limit;
     const items = hasMore ? docs.slice(0, limit) : docs;
+    const withFavorites = applyFavoriteFlag(items, favoriteSet);
 
     return res.json({
-      recipes: items,
+      recipes: withFavorites,
       hasMore,
       nextCursor: items.length ? String(items[items.length - 1]._id) : null,
     });
   } catch (error) {
+    if (error?.status) {
+      return res.status(error.status).json({ message: error.message });
+    }
     console.error("getRecipesController error:", error);
     return res.status(500).json({ message: "Internal server error" });
   }
@@ -44,10 +98,24 @@ export async function getRecipesController(req, res) {
  */
 export async function createRecipeController(req, res) {
   try {
-    const userId=req.body.userId;
-    const { title, imageUrl, description, ingredients, instructions ,videoUrl} = req.body.recipe;
+    const userId = req.body.userId;
+    if (!mongoose.isValidObjectId(userId)) {
+      return res.status(400).json({ message: "Invalid user id" });
+    }
+    const recipePayload = req.body.recipe || {};
+    const {
+      title,
+      imageUrl,
+      description,
+      ingredients,
+      instructions,
+      videoUrl,
+      time,
+      difficulty,
+      isVeg,
+      isTrending,
+    } = recipePayload;
 
-   
     const newRecipe = await recipeModel.create({
       title,
       imageUrl,
@@ -55,7 +123,11 @@ export async function createRecipeController(req, res) {
       ingredients,
       instructions,
       videoUrl,
-      createdBy:userId
+      time: parseNumber(time),
+      difficulty: normalizeDifficulty(difficulty),
+      isVeg: parseBoolean(isVeg),
+      isTrending: parseBoolean(isTrending),
+      createdBy: userId,
     });
 
     return res.status(201).json({ recipe: newRecipe, userId });
@@ -75,8 +147,20 @@ export async function deleteRecipeController(req, res) {
       return res.status(400).json({ message: "Invalid id" });
     }
 
-    const recipe = await recipeModel.findByIdAndDelete(id);
-    if (!recipe) return res.status(404).json({ message: "Recipe not found" });
+    const userId = req.body?.userId || req.query?.userId;
+    if (!mongoose.isValidObjectId(userId)) {
+      return res.status(400).json({ message: "Invalid user id" });
+    }
+
+    const recipe = await recipeModel.findById(id);
+    if (!recipe) {
+      return res.status(404).json({ message: "Recipe not found" });
+    }
+    if (String(recipe.createdBy) !== String(userId)) {
+      return res.status(403).json({ message: "Not allowed to delete this recipe" });
+    }
+
+    await recipe.deleteOne();
     return res.status(200).json({ message: "Recipe deleted successfully" });
   } catch (error) {
     console.error("deleteRecipeController error:", error);
@@ -91,23 +175,88 @@ export async function updateRecipeController(req, res) {
       return res.status(400).json({ message: "Invalid id" });
     }
 
-    const data = { ...req.body };
-
-    Object.keys(data).forEach((key) => {
-      if (data[key] === "" || data[key] === null || data[key] === undefined) {
-        delete data[key];
-      }
-    });
-
-    if (Object.keys(data).length === 0) {
-      return res.status(400).json({ message: "No valid fields to update" });
+    const userId = req.body?.userId;
+    if (!mongoose.isValidObjectId(userId)) {
+      return res.status(400).json({ message: "Invalid user id" });
     }
 
-    const recipe = await recipeModel.findByIdAndUpdate(id, { $set: data }, { new: true, runValidators: true });
+    const recipe = await recipeModel.findById(id);
     if (!recipe) {
       return res.status(404).json({ message: "Recipe not found" });
     }
-    return res.status(200).json({ message: "Recipe updated successfully", recipe });
+    if (String(recipe.createdBy) !== String(userId)) {
+      return res.status(403).json({ message: "Not allowed to update this recipe" });
+    }
+
+    const allowedFields = [
+      "title",
+      "imageUrl",
+      "description",
+      "ingredients",
+      "instructions",
+      "videoUrl",
+      "time",
+      "difficulty",
+      "isVeg",
+      "isTrending",
+    ];
+
+    const updates = {};
+    for (const field of allowedFields) {
+      const value = req.body?.[field];
+      if (value !== "" && value !== null && value !== undefined) {
+        updates[field] = value;
+      }
+    }
+
+    if (updates.time !== undefined) {
+      const parsedTime = parseNumber(updates.time);
+      if (parsedTime === undefined) {
+        delete updates.time;
+      } else {
+        updates.time = parsedTime;
+      }
+    }
+
+    if (updates.difficulty !== undefined) {
+      const normalizedDifficulty = normalizeDifficulty(updates.difficulty);
+      if (!normalizedDifficulty) {
+        delete updates.difficulty;
+      } else {
+        updates.difficulty = normalizedDifficulty;
+      }
+    }
+
+    if (updates.isVeg !== undefined) {
+      const parsedIsVeg = parseBoolean(updates.isVeg);
+      if (parsedIsVeg === undefined) {
+        delete updates.isVeg;
+      } else {
+        updates.isVeg = parsedIsVeg;
+      }
+    }
+
+    if (updates.isTrending !== undefined) {
+      const parsedIsTrending = parseBoolean(updates.isTrending);
+      if (parsedIsTrending === undefined) {
+        delete updates.isTrending;
+      } else {
+        updates.isTrending = parsedIsTrending;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ message: "No valid fields to update" });
+    }
+
+    const updatedRecipe = await recipeModel.findByIdAndUpdate(
+      id,
+      { $set: updates },
+      { new: true, runValidators: true }
+    );
+    return res
+      .status(200)
+      .json({ message: "Recipe updated successfully", recipe: updatedRecipe });
   } catch (error) {
     console.error("updateRecipeController error:", error);
     return res.status(500).json({ message: "Internal server error" });
@@ -117,17 +266,65 @@ export async function updateRecipeController(req, res) {
 
 export async function getMyRecipesController(req, res) {
   try {
-    //  console.log(req.body);
-    //  const {userId}=req.body;
-    const params=req.params;
-    const userId=params.id;
-    //  console.log(params.id)
-     const myRecipe=await recipeModel.find({createdBy:userId}).sort({createdAt:-1}).lean();
-     res.status(200).json({myRecipe})
+    const userId = req.params.id;
+    const favoriteSet = await buildFavoriteSet(userId);
+    const myRecipe = await recipeModel
+      .find({ createdBy: userId })
+      .sort({ createdAt: -1 })
+      .lean();
+    const withFavorites = applyFavoriteFlag(myRecipe, favoriteSet);
+    res.status(200).json({ myRecipe: withFavorites });
 
      
   } catch (error) {
+    if (error?.status) {
+      return res.status(error.status).json({ message: error.message });
+    }
     console.error("getRecipesController error:", error);
+    return res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+export async function setFavoriteController(req, res) {
+  try {
+    const recipeId = req.params.id;
+    const userId = req.body?.userId;
+    const favorite =
+      typeof req.body?.favorite === "boolean"
+        ? req.body.favorite
+        : typeof req.body?.fav === "boolean"
+          ? req.body.fav
+          : undefined;
+
+    if (!mongoose.isValidObjectId(recipeId)) {
+      return res.status(400).json({ message: "Invalid recipe id" });
+    }
+    if (!mongoose.isValidObjectId(userId)) {
+      return res.status(400).json({ message: "Invalid user id" });
+    }
+    if (favorite === undefined) {
+      return res.status(400).json({ message: "Favorite flag is required" });
+    }
+
+    const [user, recipe] = await Promise.all([
+      userModel.findById(userId).select("_id favorites"),
+      recipeModel.findById(recipeId).select("_id"),
+    ]);
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+    if (!recipe) {
+      return res.status(404).json({ message: "Recipe not found" });
+    }
+
+    const update = favorite
+      ? { $addToSet: { favorites: recipe._id } }
+      : { $pull: { favorites: recipe._id } };
+    await userModel.updateOne({ _id: userId }, update);
+
+    return res.status(200).json({ favorite });
+  } catch (error) {
+    console.error("setFavoriteController error:", error);
     return res.status(500).json({ message: "Internal server error" });
   }
 }

--- a/backend/src/controllers/videos.controller.js
+++ b/backend/src/controllers/videos.controller.js
@@ -1,43 +1,20 @@
 import { recipeModel } from "../models/recipe.model.js";
 import { userModel } from "../models/user.model.js";
-import mongoose from "mongoose";
-
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const parseBoolean = (value) => {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true") return true;
-    if (normalized === "false") return false;
-  }
-  return undefined;
-};
-
-const parseNumber = (value) => {
-  if (value === "" || value === null || value === undefined) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-};
-
-const normalizeDifficulty = (value) => {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim().toLowerCase();
-  return normalized ? normalized : undefined;
-};
+import {
+  assertObjectId,
+  createHttpError,
+  escapeRegex,
+  normalizeDifficulty,
+  parseBoolean,
+  parseNumber,
+} from "../utils/validation.js";
 
 const buildFavoriteSet = async (userId) => {
   if (!userId) return null;
-  if (!mongoose.isValidObjectId(userId)) {
-    const error = new Error("Invalid user id");
-    error.status = 400;
-    throw error;
-  }
+  assertObjectId(userId, "Invalid user id");
   const user = await userModel.findById(userId).select("favorites").lean();
   if (!user) {
-    const error = new Error("User not found");
-    error.status = 404;
-    throw error;
+    throw createHttpError(404, "User not found");
   }
   return new Set((user.favorites || []).map((id) => String(id)));
 };

--- a/backend/src/controllers/videos.controller.js
+++ b/backend/src/controllers/videos.controller.js
@@ -1,16 +1,103 @@
 import { recipeModel } from "../models/recipe.model.js";
+import { userModel } from "../models/user.model.js";
+import mongoose from "mongoose";
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const parseBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return undefined;
+};
+
+const parseNumber = (value) => {
+  if (value === "" || value === null || value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const normalizeDifficulty = (value) => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized ? normalized : undefined;
+};
+
+const buildFavoriteSet = async (userId) => {
+  if (!userId) return null;
+  if (!mongoose.isValidObjectId(userId)) {
+    const error = new Error("Invalid user id");
+    error.status = 400;
+    throw error;
+  }
+  const user = await userModel.findById(userId).select("favorites").lean();
+  if (!user) {
+    const error = new Error("User not found");
+    error.status = 404;
+    throw error;
+  }
+  return new Set((user.favorites || []).map((id) => String(id)));
+};
 
 export async function getVideosController(req, res) {
   try {
-    const videos = await recipeModel.find({
+    const { search, maxTime, difficulty, veg, trending, userId } = req.query;
+
+    const query = {
       videoUrl: {
         $exists: true,
         $nin: ["", null],
       },
-    });
+    };
 
-    return res.status(200).json(videos);
+    if (search) {
+      const safeSearch = escapeRegex(search);
+      query.$or = [
+        { title: { $regex: safeSearch, $options: "i" } },
+        { description: { $regex: safeSearch, $options: "i" } },
+      ];
+    }
+
+    const parsedMaxTime = parseNumber(maxTime);
+    if (parsedMaxTime !== undefined) {
+      query.time = { $lte: parsedMaxTime };
+    }
+
+    const normalizedDifficulty = normalizeDifficulty(difficulty);
+    if (normalizedDifficulty) {
+      query.difficulty = normalizedDifficulty;
+    }
+
+    const parsedVeg = parseBoolean(veg);
+    if (parsedVeg !== undefined) {
+      query.isVeg = parsedVeg;
+    }
+
+    const parsedTrending = parseBoolean(trending);
+    if (parsedTrending !== undefined) {
+      query.isTrending = parsedTrending;
+    }
+
+    const favoriteSet = await buildFavoriteSet(userId);
+    const videos = await recipeModel
+      .find(query)
+      .sort({ createdAt: -1 })
+      .lean();
+    const withFavorites = favoriteSet
+      ? videos.map((video) => ({
+          ...video,
+          fav: favoriteSet.has(String(video._id)),
+        }))
+      : videos;
+
+    return res.status(200).json({ videos: withFavorites });
   } catch (error) {
+    if (error?.status) {
+      return res.status(error.status).json({ message: error.message });
+    }
     console.log(error);
     return res.status(500).json({ message: "Internal server error" });
   }

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -1,0 +1,20 @@
+import { assertObjectId } from "../utils/validation.js";
+
+const extractUserId = (req) =>
+  req.body?.userId || req.query?.userId || req.headers["x-user-id"];
+
+export const requireUserId = (req, res, next) => {
+  try {
+    const userId = extractUserId(req);
+    if (!userId) {
+      return res.status(401).json({ message: "User id required" });
+    }
+    assertObjectId(userId, "Invalid user id");
+    req.userId = userId;
+    return next();
+  } catch (error) {
+    return res.status(error?.status || 400).json({
+      message: error?.message || "Invalid user id",
+    });
+  }
+};

--- a/backend/src/models/recipe.model.js
+++ b/backend/src/models/recipe.model.js
@@ -30,6 +30,15 @@ const recipeSchema = new mongoose.Schema(
       type: String,
       required: [true, "instructions are required"],
     },
+    time: { type: Number, min: 1 },
+    difficulty: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      enum: ["easy", "medium", "hard"],
+    },
+    isVeg: { type: Boolean },
+    isTrending: { type: Boolean },
     createdBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "users",

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -16,6 +16,10 @@ const userSchema = new mongoose.Schema(
     password: { type: String, required: [true, "password required"] },
     avatar: { type: String, trim: true, default: "" },
     bio: { type: String, trim: true, default: "", maxlength: 280 },
+    favorites: {
+      type: [{ type: mongoose.Schema.Types.ObjectId, ref: "recipe" }],
+      default: [],
+    },
   },
   { timestamps: true }
 );

--- a/backend/src/routes/recipe.routes.js
+++ b/backend/src/routes/recipe.routes.js
@@ -7,14 +7,15 @@ import {
   setFavoriteController,
 } from "../controllers/recipes.controller.js";
 import { getMyRecipesController } from "../controllers/recipes.controller.js";
+import { requireUserId } from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
 router.get('/recipes',getRecipesController)
-router.post('/recipes',createRecipeController)
-router.delete('/recipes/:id',deleteRecipeController)
-router.patch('/recipes/:id',updateRecipeController)
-router.post("/recipes/:id/favorite", setFavoriteController);
+router.post('/recipes',requireUserId,createRecipeController)
+router.delete('/recipes/:id',requireUserId,deleteRecipeController)
+router.patch('/recipes/:id',requireUserId,updateRecipeController)
+router.post("/recipes/:id/favorite", requireUserId, setFavoriteController);
 
 router.get('/user/:id/myRecipes',getMyRecipesController)
 

--- a/backend/src/routes/recipe.routes.js
+++ b/backend/src/routes/recipe.routes.js
@@ -1,5 +1,11 @@
 import express from "express";
-import {getRecipesController,createRecipeController,updateRecipeController,deleteRecipeController} from '../controllers/recipes.controller.js'
+import {
+  getRecipesController,
+  createRecipeController,
+  updateRecipeController,
+  deleteRecipeController,
+  setFavoriteController,
+} from "../controllers/recipes.controller.js";
 import { getMyRecipesController } from "../controllers/recipes.controller.js";
 
 const router = express.Router();
@@ -8,6 +14,7 @@ router.get('/recipes',getRecipesController)
 router.post('/recipes',createRecipeController)
 router.delete('/recipes/:id',deleteRecipeController)
 router.patch('/recipes/:id',updateRecipeController)
+router.post("/recipes/:id/favorite", setFavoriteController);
 
 router.get('/user/:id/myRecipes',getMyRecipesController)
 

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import {
+  getUserFavoritesController,
   randomBioController,
   updateUserController,
   userRegisterController,
@@ -11,6 +12,7 @@ const router = express.Router();
 router.post("/register", userRegisterController);
 router.post("/login", userLoginController);
 router.patch("/user/:id", updateUserController);
+router.get("/user/:id/favorites", getUserFavoritesController);
 router.get("/random-bio", randomBioController);
 
 export default router;

--- a/backend/src/services/recipes.service.js
+++ b/backend/src/services/recipes.service.js
@@ -1,0 +1,226 @@
+import mongoose from "mongoose";
+import { recipeModel } from "../models/recipe.model.js";
+import { userModel } from "../models/user.model.js";
+import {
+  assertObjectId,
+  createHttpError,
+  normalizeDifficulty,
+  parseBoolean,
+  parseNumber,
+} from "../utils/validation.js";
+
+const buildFavoriteSet = async (userId) => {
+  if (!userId) return null;
+  assertObjectId(userId, "Invalid user id");
+  const user = await userModel.findById(userId).select("favorites").lean();
+  if (!user) {
+    throw createHttpError(404, "User not found");
+  }
+  return new Set((user.favorites || []).map((id) => String(id)));
+};
+
+const applyFavoriteFlag = (items, favoriteSet) => {
+  if (!favoriteSet) return items;
+  return items.map((item) => ({
+    ...item,
+    fav: favoriteSet.has(String(item._id)),
+  }));
+};
+
+export const getRecipes = async ({ limit, after, userId }) => {
+  const parsedLimit = Math.max(1, parseInt(limit, 10) || 6);
+  const favoriteSet = await buildFavoriteSet(userId);
+
+  const query = {};
+  if (after) {
+    assertObjectId(after, "Invalid cursor (after)");
+    query._id = { $lt: new mongoose.Types.ObjectId(after) };
+  }
+
+  const docs = await recipeModel
+    .find(query)
+    .populate("createdBy", "username avatar")
+    .sort({ _id: -1 })
+    .limit(parsedLimit + 1)
+    .lean();
+
+  const hasMore = docs.length > parsedLimit;
+  const items = hasMore ? docs.slice(0, parsedLimit) : docs;
+  const withFavorites = applyFavoriteFlag(items, favoriteSet);
+
+  return {
+    recipes: withFavorites,
+    hasMore,
+    nextCursor: items.length ? String(items[items.length - 1]._id) : null,
+  };
+};
+
+export const createRecipe = async ({ userId, recipe }) => {
+  assertObjectId(userId, "Invalid user id");
+  const recipePayload = recipe || {};
+  const {
+    title,
+    imageUrl,
+    description,
+    ingredients,
+    instructions,
+    videoUrl,
+    time,
+    difficulty,
+    isVeg,
+    isTrending,
+  } = recipePayload;
+
+  const newRecipe = await recipeModel.create({
+    title,
+    imageUrl,
+    description,
+    ingredients,
+    instructions,
+    videoUrl,
+    time: parseNumber(time),
+    difficulty: normalizeDifficulty(difficulty),
+    isVeg: parseBoolean(isVeg),
+    isTrending: parseBoolean(isTrending),
+    createdBy: userId,
+  });
+
+  return newRecipe;
+};
+
+export const deleteRecipe = async ({ recipeId, userId }) => {
+  assertObjectId(recipeId, "Invalid id");
+  assertObjectId(userId, "Invalid user id");
+
+  const recipe = await recipeModel.findById(recipeId);
+  if (!recipe) {
+    throw createHttpError(404, "Recipe not found");
+  }
+  if (String(recipe.createdBy) !== String(userId)) {
+    throw createHttpError(403, "Not allowed to delete this recipe");
+  }
+
+  await recipe.deleteOne();
+};
+
+export const updateRecipe = async ({ id, userId, data }) => {
+  assertObjectId(id, "Invalid id");
+  assertObjectId(userId, "Invalid user id");
+
+  const recipe = await recipeModel.findById(id);
+  if (!recipe) {
+    throw createHttpError(404, "Recipe not found");
+  }
+  if (String(recipe.createdBy) !== String(userId)) {
+    throw createHttpError(403, "Not allowed to update this recipe");
+  }
+
+  const allowedFields = [
+    "title",
+    "imageUrl",
+    "description",
+    "ingredients",
+    "instructions",
+    "videoUrl",
+    "time",
+    "difficulty",
+    "isVeg",
+    "isTrending",
+  ];
+
+  const updates = {};
+  for (const field of allowedFields) {
+    const value = data?.[field];
+    if (value !== "" && value !== null && value !== undefined) {
+      updates[field] = value;
+    }
+  }
+
+  if (updates.time !== undefined) {
+    const parsedTime = parseNumber(updates.time);
+    if (parsedTime === undefined) {
+      delete updates.time;
+    } else {
+      updates.time = parsedTime;
+    }
+  }
+
+  if (updates.difficulty !== undefined) {
+    const normalizedDifficulty = normalizeDifficulty(updates.difficulty);
+    if (!normalizedDifficulty) {
+      delete updates.difficulty;
+    } else {
+      updates.difficulty = normalizedDifficulty;
+    }
+  }
+
+  if (updates.isVeg !== undefined) {
+    const parsedIsVeg = parseBoolean(updates.isVeg);
+    if (parsedIsVeg === undefined) {
+      delete updates.isVeg;
+    } else {
+      updates.isVeg = parsedIsVeg;
+    }
+  }
+
+  if (updates.isTrending !== undefined) {
+    const parsedIsTrending = parseBoolean(updates.isTrending);
+    if (parsedIsTrending === undefined) {
+      delete updates.isTrending;
+    } else {
+      updates.isTrending = parsedIsTrending;
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw createHttpError(400, "No valid fields to update");
+  }
+
+  return recipeModel.findByIdAndUpdate(
+    id,
+    { $set: updates },
+    { new: true, runValidators: true }
+  );
+};
+
+export const getMyRecipes = async ({ userId }) => {
+  const favoriteSet = await buildFavoriteSet(userId);
+  const myRecipe = await recipeModel
+    .find({ createdBy: userId })
+    .sort({ createdAt: -1 })
+    .lean();
+  return applyFavoriteFlag(myRecipe, favoriteSet);
+};
+
+export const setFavorite = async ({ recipeId, userId, favorite, fav }) => {
+  assertObjectId(recipeId, "Invalid recipe id");
+  assertObjectId(userId, "Invalid user id");
+
+  const favoriteValue =
+    typeof favorite === "boolean"
+      ? favorite
+      : typeof fav === "boolean"
+        ? fav
+        : undefined;
+  if (favoriteValue === undefined) {
+    throw createHttpError(400, "Favorite flag is required");
+  }
+
+  const [user, recipe] = await Promise.all([
+    userModel.findById(userId).select("_id favorites"),
+    recipeModel.findById(recipeId).select("_id"),
+  ]);
+  if (!user) {
+    throw createHttpError(404, "User not found");
+  }
+  if (!recipe) {
+    throw createHttpError(404, "Recipe not found");
+  }
+
+  const update = favoriteValue
+    ? { $addToSet: { favorites: recipe._id } }
+    : { $pull: { favorites: recipe._id } };
+  await userModel.updateOne({ _id: userId }, update);
+
+  return { favorite: favoriteValue };
+};

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -1,0 +1,38 @@
+import mongoose from "mongoose";
+
+export const createHttpError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+export const assertObjectId = (value, message = "Invalid id") => {
+  if (!mongoose.isValidObjectId(value)) {
+    throw createHttpError(400, message);
+  }
+};
+
+export const parseBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return undefined;
+};
+
+export const parseNumber = (value) => {
+  if (value === "" || value === null || value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const normalizeDifficulty = (value) => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized ? normalized : undefined;
+};
+
+export const escapeRegex = (value) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,8 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
-eslint.config.js
-
 
 node_modules
 dist

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,29 @@
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  {
+    files: ["**/*.{js,jsx}"],
+    ignores: ["dist/**", "node_modules/**"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: "off",
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {},
+  },
+];

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import { NavLink } from "react-router-dom";
+import { useState } from "react";
 import styles from "../cssFiles/Navbar.module.css";
 import userStyles from "../cssFiles/userUi.module.css";
 import { useDispatch, useSelector } from "react-redux";
@@ -9,13 +10,33 @@ const Navbar = () => {
   const dispatch = useDispatch();
   // const isUser = useSelector((state) => state.users.data);
   const isUser = useSelector((state) => state?.users?.data?.data?.user);
+  const [isOpen, setIsOpen] = useState(false);
   const logoutHandler = () => {
     dispatch(resetUser());
     // navigate('/home');
   };
+  const toggleMenu = () => {
+    setIsOpen((prev) => !prev);
+  };
+  const closeMenu = () => {
+    setIsOpen(false);
+  };
   return (
     <div className={styles.navbar}>
-      <nav>
+      <button
+        type="button"
+        className={styles.menuToggle}
+        onClick={toggleMenu}
+        aria-expanded={isOpen}
+        aria-controls="navbar-links"
+        aria-label="Toggle navigation"
+      >
+        ...
+      </button>
+      <nav
+        id="navbar-links"
+        className={`${styles.navLinks} ${isOpen ? styles.navLinksOpen : ""}`}
+      >
         {/* protected routes */}
         {isUser ? (
           <>
@@ -23,6 +44,7 @@ const Navbar = () => {
           
             <NavLink
               to={`/user/${isUser._id}/profile`}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               <img 
@@ -37,6 +59,7 @@ const Navbar = () => {
             </NavLink>
             <NavLink
               to={`/user/${isUser._id}/MyRecipes`}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               MyRecipes
@@ -45,12 +68,14 @@ const Navbar = () => {
             <NavLink
             // /user/:id/AddRecipe/</>
               to={`/user/${isUser._id}/AddRecipe/`}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               Create Recipe
             </NavLink>
             <NavLink
               to={`/user/${isUser._id}/favorites`}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               Favorites
@@ -60,6 +85,7 @@ const Navbar = () => {
               onClick={() => {
                 localStorage.removeItem("token");
                 logoutHandler();
+                closeMenu();
               }}
             >
               Logout
@@ -69,12 +95,14 @@ const Navbar = () => {
           <>
             <NavLink
               to={"/register"}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               Register
             </NavLink>
             <NavLink
               to={"/"}
+              onClick={closeMenu}
               className={({ isActive }) => (isActive ? styles.isActive : "")}
             >
               Login
@@ -83,18 +111,21 @@ const Navbar = () => {
         )}
         <NavLink
           to={`/user/${isUser._id}/Home`}
+          onClick={closeMenu}
           className={({ isActive }) => (isActive ? styles.isActive : "")}
         >
           Home
         </NavLink>
         <NavLink
           to="/about"
+          onClick={closeMenu}
           className={({ isActive }) => (isActive ? styles.isActive : "")}
         >
           About
         </NavLink>
         <NavLink
           to={`/user/${isUser._id}/recipes/`}
+          onClick={closeMenu}
           className={({ isActive }) => (isActive ? styles.isActive : "")}
         >
           Recipes

--- a/frontend/src/components/RecipeCard.jsx
+++ b/frontend/src/components/RecipeCard.jsx
@@ -4,10 +4,10 @@ import styles from "../cssFiles/cards.module.css";
 import { useDispatch } from "react-redux";
 import { asyncAddToFavorite } from "../store/actions/recipeAction";
 import { toast } from "react-toastify";
-import { useEffect } from "react";
 import PixelTransition from '../utils/animations/PixelTransition/PixelTransition';
-const RecipeCard = ({ item }) => {
+const RecipeCard = ({ item, showOwnerActions = false, onEdit, onDelete }) => {
   const nav = useNavigate();
+  const currentUserId = useSelector((state) => state?.users?.data?.data?.user?._id);
 
   const {
     _id,
@@ -16,14 +16,23 @@ const RecipeCard = ({ item }) => {
     description,
     time = "30 min",
     difficulty = "Easy",
-    fav,
+    fav = false,
     onView,
     onToggleFavorite,
   } = item;
   const dispatch = useDispatch();
-  const recipe = useSelector((state) => state.recipes.data);
-  const filteredData = recipe?.find((f) => f._id == _id);
-
+  const ownerId = item?.createdBy?._id ?? item?.createdBy;
+  const isOwner = currentUserId && String(ownerId) === String(currentUserId);
+  const parsedTime = Number(time);
+  const displayTime = Number.isFinite(parsedTime)
+    ? `${parsedTime} min`
+    : time
+      ? time
+      : "5 min";
+  const displayDifficulty =
+    typeof difficulty === "string" && difficulty
+      ? difficulty[0].toUpperCase() + difficulty.slice(1)
+      : difficulty || "Easy";
   const favorite = () => {
     const favResult = !fav;
 
@@ -94,17 +103,30 @@ const RecipeCard = ({ item }) => {
 
         {/* Meta Info */}
         <div className={styles.meta}>
-          <span>⏱ {time ? time : "5min"}</span>
-          <span>⭐ {difficulty ? difficulty : 5}</span>
+          <span>⏱ {displayTime}</span>
+          <span>⭐ {displayDifficulty}</span>
         </div>
 
         {/* CTA */}
-        <button className={styles.viewBtn} onClick={viewRecipe}>
-          View Recipe
-        </button>
+        <div className={styles.actions}>
+          <button className={styles.viewBtn} onClick={viewRecipe}>
+            View Recipe
+          </button>
+          {showOwnerActions && isOwner ? (
+            <div className={styles.ownerActions}>
+              <button className={styles.editBtn} onClick={onEdit}>
+                Edit
+              </button>
+              <button className={styles.deleteBtn} onClick={onDelete}>
+                Delete
+              </button>
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );
 };
 
 export default RecipeCard;
+

--- a/frontend/src/components/VideoCard.jsx
+++ b/frontend/src/components/VideoCard.jsx
@@ -16,7 +16,8 @@ const VideoCard = ({ video }) => {
   const navigate = useNavigate();
   const [isHover, setIsHover] = useState(false);
 
-  const duration = "20 mins";
+  const parsedTime = Number(video?.time);
+  const duration = Number.isFinite(parsedTime) ? `${parsedTime} min` : "20 min";
 
   const getYoutubeId = (url) => {
     const match = url.match(

--- a/frontend/src/components/useRecipeForm.jsx
+++ b/frontend/src/components/useRecipeForm.jsx
@@ -14,40 +14,28 @@ import { useNavigate, useParams } from "react-router-dom";
 export default function useRecipeForm() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const recipe = useSelector((state) => state.recipes.data);
   const params = useParams();
   
-  const isUser = useSelector((state) => state.users.data);
-  // const currentUser=localStorage.getItem('user');
-  const userId=isUser.data.user._id;
-  const defaultRecipe = recipe.find((f) => f.id == params.id);
+  const userId = useSelector((state) => state?.users?.data?.data?.user?._id);
 
   const createRecipeHandler = useCallback(
     async (data) => {
-      // const newData={}
-      
-      // console.log('tetsing :' ,  );
-      
-      dispatch(asyncAddRecipeActions(data,userId));
-      navigate(`/user/${isUser.data.user._id}/recipes/`);
+      if (!userId) return;
+      dispatch(asyncAddRecipeActions(data, userId));
+      navigate(`/user/${userId}/recipes/`);
     },
-    [dispatch, navigate]
+    [dispatch, navigate, userId]
   );
  
-  const updateRecipeHandler = async (defaultRecipe) => {
-    const id = params.id;
-    console.log(id);
-    
-
-    dispatch(asyncUpdateRecipeHandler({ id, defaultRecipe }));
-    console.log("updateRecipeHandler");
-
-    reset();
-    navigate("/recipes");
-
-    toast.success("recipe data updated successfully!!");
-    navigate("/recipes");
-  };
+  const updateRecipeHandler = useCallback(
+    async (data) => {
+      const id = params.id;
+      if (!id || !userId) return;
+      await dispatch(asyncUpdateRecipeHandler({ id, data }));
+      navigate(`/user/${userId}/MyRecipes`);
+    },
+    [dispatch, navigate, params.id, userId]
+  );
 
   return { createRecipeHandler, updateRecipeHandler };
 }

--- a/frontend/src/cssFiles/Navbar.module.css
+++ b/frontend/src/cssFiles/Navbar.module.css
@@ -15,6 +15,24 @@
   border-bottom: 1px solid var(--border);
   padding: 0.8rem 1rem;
 }
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.menuToggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: var(--white);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
 .navbar .avatar {
   border-radius: 100%;
   width: 25px;
@@ -54,12 +72,29 @@
   .navbar {
     width: 100%;
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
     flex-direction: row;
-    gap: 0.1rem;
+    gap: 0.4rem;
     flex-wrap: wrap;
     font-size: clamp(1rem, 1vw + 0.75rem, 0.5rem);
-    padding: 0.1rem;
+    padding: 0.6rem 0.8rem;
+  }
+  .menuToggle {
+    display: inline-flex;
+  }
+  .navLinks {
+    display: none;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+    padding: 0.6rem 0;
+  }
+  .navLinksOpen {
+    display: flex;
+  }
+  .navLinks a {
+    width: 100%;
   }
 }/*# sourceMappingURL=Navbar.module.css.map */

--- a/frontend/src/cssFiles/Navbar.module.scss
+++ b/frontend/src/cssFiles/Navbar.module.scss
@@ -61,13 +61,50 @@
   
 }
 
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.menuToggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: var(--white);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 @include responsive(tablet){
   .navbar{
     width: 100%;
-    @include flex(center,center,row,.1rem,wrap);
+    @include flex(space-between,center,row,.4rem,wrap);
     font-size: clamp(1rem, 1vw + 0.75rem, .5rem);
-    padding: .1rem;
+    padding: .6rem .8rem;
     // margin: .1rem;
+  }
+  .menuToggle {
+    display: inline-flex;
+  }
+  .navLinks {
+    display: none;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+    padding: 0.6rem 0;
+  }
+  .navLinksOpen {
+    display: flex;
+  }
+  .navLinks a {
+    width: 100%;
   }
 }
 

--- a/frontend/src/cssFiles/cards.module.css
+++ b/frontend/src/cssFiles/cards.module.css
@@ -120,6 +120,14 @@
 }
 
 /* BUTTON */
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
 .viewBtn {
   margin-top: 0.7rem;
   background: var(--primary);
@@ -135,6 +143,38 @@
 .viewBtn:hover {
   filter: brightness(0.92);
   transform: translateY(-2px);
+}
+
+.ownerActions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.7rem;
+}
+
+.editBtn,
+.deleteBtn {
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--primary);
+}
+
+.editBtn:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.deleteBtn {
+  border-color: #e28d8d;
+  color: #b94a4a;
+}
+
+.deleteBtn:hover {
+  background: rgba(226, 141, 141, 0.15);
 }
 
 /* RESPONSIVE */

--- a/frontend/src/cssFiles/cards.module.scss
+++ b/frontend/src/cssFiles/cards.module.scss
@@ -123,6 +123,14 @@
 }
 
 /* BUTTON */
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
 .viewBtn {
   margin-top: 0.7rem;
   background: var(--primary);
@@ -139,6 +147,38 @@
     filter: brightness(0.92);
     transform: translateY(-2px);
   }
+}
+
+.ownerActions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.7rem;
+}
+
+.editBtn,
+.deleteBtn {
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--primary);
+}
+
+.editBtn:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.deleteBtn {
+  border-color: #e28d8d;
+  color: #b94a4a;
+}
+
+.deleteBtn:hover {
+  background: rgba(226, 141, 141, 0.15);
 }
 
 /* RESPONSIVE */

--- a/frontend/src/pages/Favorites.jsx
+++ b/frontend/src/pages/Favorites.jsx
@@ -1,19 +1,28 @@
-import React, { useContext } from "react";
+import React, { useEffect } from "react";
 // import { AppContent } from "../context/recipeContext";
 import RecipeCard from "../components/RecipeCard";
 import styles from "../cssFiles/cards.module.css";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { asyncGetFavoritesActions } from "../store/actions/recipeAction";
 
 const Favorites = () => {
   // const { recipe } = useContext(AppContent);
-  const recipe = useSelector((state) => state.recipes.data);
-  const filtered = recipe.filter((f) => f.fav == true);
-  const mapped = filtered.map((item, i) => (
+  const dispatch = useDispatch();
+  const userId = useSelector((state) => state?.users?.data?.data?.user?._id);
+  const favorites = useSelector((state) => state.favorites.data) || [];
+
+  useEffect(() => {
+    if (userId) {
+      dispatch(asyncGetFavoritesActions(userId));
+    }
+  }, [dispatch, userId]);
+
+  const mapped = favorites.map((item, i) => (
     <RecipeCard key={item.id ? item.id : i} item={item} />
   ));
   return (
     <div >
-      {filtered?.length > 0 ? mapped : <h2>"No Favorites found !!"</h2>}
+      {favorites?.length > 0 ? mapped : <h2>"No Favorites found !!"</h2>}
     </div>
   );
 };

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -25,8 +25,10 @@ const Home = () => {
   const containerRef = useRef(null);
   const userId = useSelector((state) => state?.users?.data?.data?.user?._id);
   useEffect(() => {
-    dispatch(asyncGetLimitRecipies(6));
-  }, [dispatch]);
+    if (userId) {
+      dispatch(asyncGetLimitRecipies(6));
+    }
+  }, [dispatch, userId]);
   // const { recipe, fetchRecipes, isLoading } = useInfiniteRecipe();
   const recipe = useSelector((state) => state.recipes.data);
   const recipeList = Array.isArray(recipe) ? recipe.slice(0, 6) : [];

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import axios from "../utils/axios";
 import { asyncUpdateUser } from "../store/actions/userAction";
 import formStyles from "../styles/formStyles.module.css";
+import { asyncGetFavoritesActions } from "../store/actions/recipeAction";
 
 const Profile = () => {
   // const [activeTab, setActiveTab] = useState("recipes");
@@ -16,8 +17,10 @@ const Profile = () => {
   const currentUser = useSelector((state) => state?.users?.data?.data?.user);
 
   const userRecipes = useSelector((state) => state?.recipes?.MyRecipes);
+  const favorites = useSelector((state) => state?.favorites?.data) || [];
 
   const recipeCount = Array.isArray(userRecipes) ? userRecipes.length : 0;
+  const favoritesCount = Array.isArray(favorites) ? favorites.length : 0;
   const joinedYear = currentUser?.createdAt
     ? new Date(currentUser.createdAt).getFullYear()
     : "N/A";
@@ -49,6 +52,12 @@ const Profile = () => {
       password: "",
     });
   }, [currentUser, reset]);
+
+  useEffect(() => {
+    if (currentUser?._id) {
+      dispatch(asyncGetFavoritesActions(currentUser._id));
+    }
+  }, [dispatch, currentUser?._id]);
 
   useEffect(() => {
     let isActive = true;
@@ -95,6 +104,10 @@ const Profile = () => {
             <div>
               <strong>{recipeCount}</strong>
               <span>Recipes</span>
+            </div>
+            <div>
+              <strong>{favoritesCount}</strong>
+              <span>Favorites</span>
             </div>
             <div>
               <strong>{joinedYear}</strong>

--- a/frontend/src/pages/UpdateRecipe.jsx
+++ b/frontend/src/pages/UpdateRecipe.jsx
@@ -1,49 +1,135 @@
 import useRecipeForm from "../components/useRecipeForm";
 import { useForm } from "react-hook-form";
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
 
-import styles from "../cssFiles/CreateRecipe.module.css";
+import styles from "../pages/createRecipe/CreateRecipe.module.css";
 
 const UpdateRecipe = () => {
+  const { id } = useParams();
+  const recipeList = useSelector((state) => state.recipes.data) || [];
+  const myRecipes = useSelector((state) => state.recipes.MyRecipes) || [];
+  const allRecipes = [...myRecipes, ...recipeList];
+  const currentRecipe = allRecipes.find((item) => (item._id ?? item.id) === id);
 
- 
- 
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm({
+    defaultValues: {
+      imageUrl: "",
+      title: "",
+      videoUrl: "",
+      description: "",
+      ingredients: "",
+      instructions: "",
+      time: "",
+      difficulty: "",
+      isVeg: "",
+      isTrending: "",
+    },
+  });
 
-  const { register, handleSubmit, formState: { errors } } = useForm();
-    const {updateRecipeHandler}=useRecipeForm();
+  const { updateRecipeHandler } = useRecipeForm();
 
- 
+  useEffect(() => {
+    if (!currentRecipe) return;
+    reset({
+      imageUrl: currentRecipe.imageUrl || "",
+      title: currentRecipe.title || "",
+      videoUrl: currentRecipe.videoUrl || "",
+      description: currentRecipe.description || "",
+      ingredients: currentRecipe.ingredients || "",
+      instructions: currentRecipe.instructions || "",
+      time: currentRecipe.time ?? "",
+      difficulty: currentRecipe.difficulty ?? "",
+      isVeg:
+        typeof currentRecipe.isVeg === "boolean"
+          ? String(currentRecipe.isVeg)
+          : "",
+      isTrending:
+        typeof currentRecipe.isTrending === "boolean"
+          ? String(currentRecipe.isTrending)
+          : "",
+    });
+  }, [currentRecipe, reset]);
+
   return (
-    <div className={styles.recipeContainer}>
-      <form
-        className={styles.recipeForm}
-        onSubmit={handleSubmit(updateRecipeHandler)}
-      >
+    <section className={styles.page}>
+      <form className={styles.card} onSubmit={handleSubmit(updateRecipeHandler)}>
+        <h1>Update Recipe</h1>
+
+        <label>Recipe Image URL</label>
         <input
-          type="url"
-          {...register("image")}
-          placeholder="enter image url"
+          type="text"
+          {...register("imageUrl")}
+          placeholder="https://example.com/recipe.jpg"
         />
+
+        <label>Recipe Title</label>
         <input
           type="text"
           {...register("title", { required: true })}
           placeholder="recipe title"
         />
         {errors.title && <p style={{ color: "red" }}>Title is required</p>}
+
+        <label>Video URL (optional)</label>
+        <input
+          type="text"
+          {...register("videoUrl")}
+          placeholder="https://youtube.com/..."
+        />
+
+        <label>Short Description</label>
         <textarea
           {...register("description")}
           placeholder="enter the description"
         ></textarea>
+
+        <label>Ingredients</label>
         <textarea
           {...register("ingredients")}
           placeholder="enter the ingredients"
         ></textarea>
+
+        <label>Cooking Instructions</label>
         <textarea
           {...register("instructions")}
           placeholder="enter the instructions to make the recipe"
         ></textarea>
+
+        <label>Time (minutes)</label>
+        <input type="number" {...register("time")} placeholder="30" min="1" />
+
+        <label>Difficulty</label>
+        <select {...register("difficulty")}>
+          <option value="">Select difficulty</option>
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+
+        <label>Veg Option</label>
+        <select {...register("isVeg")}>
+          <option value="">Select</option>
+          <option value="true">Veg</option>
+          <option value="false">Non-Veg</option>
+        </select>
+
+        <label>Trending</label>
+        <select {...register("isTrending")}>
+          <option value="">Select</option>
+          <option value="true">Trending</option>
+          <option value="false">Not Trending</option>
+        </select>
+
         <button type="submit">Update Recipe</button>
       </form>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/pages/Videos/RecipeVideos.jsx
+++ b/frontend/src/pages/Videos/RecipeVideos.jsx
@@ -1,42 +1,42 @@
-import { useSearchParams, useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
 import styles from "../Videos/recipeVideos.module.scss";
-import useInfiniteRecipe from "../../utils/useInfiniteRecipe";
 
 import VideoCard from "../../components/VideoCard.jsx";
 
-import End from "../End";
 import RotatingText from "../../utils/animations/RotatingText/RotatingText.jsx";
-import InfiniteScroll from "react-infinite-scroll-component";
 import { useDispatch, useSelector } from "react-redux";
-import { LoadVideos } from "../../store/reducers/RecipeSlice.jsx";
 import { asyncGetVideosActions } from "../../store/actions/videosAction.jsx";
 
 const RecipeVideos = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { recipe, hasMore, fetchRecipes, isLoading } = useInfiniteRecipe();
 
   const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const videos=useSelector(state=>state.recipes.Videos.data);
+  const videos = useSelector((state) => state.recipes.Videos) || [];
 
   // ---- filters from URL ----
+  const search = searchParams.get("search");
   const veg = searchParams.get("veg");
   const maxTime = searchParams.get("maxTime");
   const difficulty = searchParams.get("difficulty");
+  const trending = searchParams.get("trending");
 
   const renderVideo = videos?.map((video, i) => {
     return <VideoCard key={video?._id || i} video={video} />;
   });
 
   useEffect(() => {
-    console.log(videos);
-    
-    dispatch(asyncGetVideosActions());
-  }, [dispatch]);
+    const filters = {};
+    if (search) filters.search = search;
+    if (veg !== null) filters.veg = veg;
+    if (maxTime) filters.maxTime = maxTime;
+    if (difficulty) filters.difficulty = difficulty;
+    if (trending) filters.trending = trending;
+    dispatch(asyncGetVideosActions(filters));
+  }, [dispatch, search, veg, maxTime, difficulty, trending]);
   const updateFilter = (key, value) => {
     const params = Object.fromEntries([...searchParams]);
-    if (value === null) delete params[key];
+    if (value === null || value === "") delete params[key];
     else params[key] = value;
     setSearchParams(params);
   };
@@ -104,16 +104,8 @@ const RecipeVideos = () => {
       </div>
       {/* videoSkeleton */}
       {/* VIDEO GRID */}
-      {recipe && recipe.length > 0 ? (
-        <InfiniteScroll
-          dataLength={recipe.length}
-          next={fetchRecipes}
-          hasMore={hasMore}
-          endMessage={<End />}
-          loader={<h2>Loading...</h2>}
-        >
-          <div className={styles.videoGrid}>{renderVideo}</div>
-        </InfiniteScroll>
+      {videos && videos.length > 0 ? (
+        <div className={styles.videoGrid}>{renderVideo}</div>
       ) : (
         "No recipes found !"
       )}

--- a/frontend/src/pages/createRecipe/CreateRecipe.jsx
+++ b/frontend/src/pages/createRecipe/CreateRecipe.jsx
@@ -82,6 +82,37 @@ const CreateRecipe = () => {
           required
         />
 
+        <label>Time (minutes)</label>
+        <input
+          type="number"
+          name="time"
+          placeholder="30"
+          min="1"
+          {...register("time")}
+        />
+
+        <label>Difficulty</label>
+        <select name="difficulty" {...register("difficulty")}>
+          <option value="">Select difficulty</option>
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+
+        <label>Veg Option</label>
+        <select name="isVeg" {...register("isVeg")}>
+          <option value="">Select</option>
+          <option value="true">Veg</option>
+          <option value="false">Non-Veg</option>
+        </select>
+
+        <label>Trending</label>
+        <select name="isTrending" {...register("isTrending")}>
+          <option value="">Select</option>
+          <option value="true">Trending</option>
+          <option value="false">Not Trending</option>
+        </select>
+
         <button type="submit" onClick={()=>{setLoading(true);}} >
           {/* <button type="submit" disabled={loading} ? dont knoow its meaning></button> */}
           {loading ? "Creating..." : "Create Recipe"}

--- a/frontend/src/pages/createRecipe/CreateRecipe.module.css
+++ b/frontend/src/pages/createRecipe/CreateRecipe.module.css
@@ -37,7 +37,8 @@ label {
 }
 
 input,
-textarea {
+textarea,
+select {
   width: 100%;
   padding: 0.7rem 0.9rem;
   margin-top: 0.4rem;
@@ -48,7 +49,8 @@ textarea {
 }
 
 input:focus,
-textarea:focus {
+textarea:focus,
+select:focus {
   outline: none;
   border-color: var(--pri);
 }

--- a/frontend/src/pages/createRecipe/CreateRecipe.module.scss
+++ b/frontend/src/pages/createRecipe/CreateRecipe.module.scss
@@ -46,7 +46,8 @@ label {
 }
 
 input,
-textarea {
+textarea,
+select {
   width: 100%;
   padding: 0.7rem 0.9rem;
   margin-top: 0.4rem;
@@ -57,7 +58,8 @@ textarea {
 }
 
 input:focus,
-textarea:focus {
+textarea:focus,
+select:focus {
   outline: none;
   border-color: var(--pri);
 }

--- a/frontend/src/pages/myRecipes/MyRecipes.jsx
+++ b/frontend/src/pages/myRecipes/MyRecipes.jsx
@@ -5,12 +5,16 @@ import styles from "../../cssFiles/cards.module.css";
 
 
 import { useDispatch, useSelector } from "react-redux";
-import axios from "../.././utils/axios";
-import { asyncGetMyRecipeActions } from "../../store/actions/recipeAction";
+import {
+  asyncDeleteRecipeAction,
+  asyncGetMyRecipeActions,
+} from "../../store/actions/recipeAction";
+import { useNavigate } from "react-router-dom";
 
 const MyRecipes = () => {
   // const { recipe } = useContext(AppContent);
-  const userId = useSelector((state) => state.users.data.data.user._id);
+  const navigate = useNavigate();
+  const userId = useSelector((state) => state?.users?.data?.data?.user?._id);
   //    const Recipe = useContext(second)
   const dispatch=useDispatch();
   // const [recipe, setrecipe] = useState([]);
@@ -18,14 +22,29 @@ const MyRecipes = () => {
   useEffect( () => {
     // console.log(isUser);
     
-     dispatch(asyncGetMyRecipeActions(userId))
+     if (userId) {
+       dispatch(asyncGetMyRecipeActions(userId));
+     }
     // setrecipe(user);
-  }, [dispatch]);
+  }, [dispatch, userId]);
 
   // const filtered = recipe.map((f) => console.log(f));
-  const mapped = recipe.map((item, i) => (
-    <RecipeCard key={item.id ? item.id : i} item={item} />
-    
+  const handleEdit = (id) => {
+    navigate(`/user/${userId}/recipe/update/${id}`);
+  };
+
+  const handleDelete = (id) => {
+    dispatch(asyncDeleteRecipeAction(id));
+  };
+
+  const mapped = (recipe || []).map((item, i) => (
+    <RecipeCard
+      key={item.id ? item.id : i}
+      item={item}
+      showOwnerActions
+      onEdit={() => handleEdit(item._id ?? item.id)}
+      onDelete={() => handleDelete(item._id ?? item.id)}
+    />
   ));
   return (
     // <>

--- a/frontend/src/pages/singleRecipePg/SingleRecipe.jsx
+++ b/frontend/src/pages/singleRecipePg/SingleRecipe.jsx
@@ -116,7 +116,9 @@ const SingleRecipe = () => {
                 </div>
               </div>
 
-              <button className={styles.favBtn} onClick={favorite}>{filteredData.fav ? 'add to fav':'remove from fav'}</button>
+              <button className={styles.favBtn} onClick={favorite}>
+                {filteredData.fav ? "Remove from favorites" : "Add to favorites"}
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/store/actions/recipeAction.jsx
+++ b/frontend/src/store/actions/recipeAction.jsx
@@ -1,10 +1,19 @@
 import axios from "../../utils/axios";
 import { toast } from "react-toastify";
-import { LoadMyRecipe,loadRecipe, toggleFavoriteLocal } from "../reducers/recipeSlice";
+import {
+  LoadMyRecipe,
+  loadRecipe,
+  toggleFavoriteLocal,
+  deleteRecipe,
+} from "../reducers/recipeSlice";
 import { loadFavorites } from "../reducers/FavoriteSlice";
-export const asyncGetRecipeActions = () => async (dispatch, getState) => {
+export const asyncGetRecipeActions = (userId) => async (dispatch, getState) => {
   try {
-    const res = await axios.get("/recipes");
+    const params = {};
+    const resolvedUserId =
+      userId ?? getState()?.users?.data?.data?.user?._id;
+    if (resolvedUserId) params.userId = resolvedUserId;
+    const res = await axios.get("/recipes", { params });
 
     dispatch(loadRecipe(res.data.recipes));
   } catch (error) {
@@ -16,7 +25,7 @@ export const asyncGetMyRecipeActions = (userId) => async (dispatch, getState) =>
   try {
     // console.log(userId);
     
-    const res = await axios.get(`/user/${userId}/myRecipes`,{userId});
+    const res = await axios.get(`/user/${userId}/myRecipes`);
     // console.log(res.data.myRecipe);
     
     dispatch(LoadMyRecipe(res.data.myRecipe));
@@ -27,7 +36,10 @@ export const asyncGetMyRecipeActions = (userId) => async (dispatch, getState) =>
 
 export const asyncGetLimitRecipies = (limit) => async (dispatch, getState) => {
   try {
-    const res = await axios.get(`/recipes?limit=${limit}&offset=0`);
+    const userId = getState()?.users?.data?.data?.user?._id;
+    const params = { limit };
+    if (userId) params.userId = userId;
+    const res = await axios.get(`/recipes`, { params });
     dispatch(loadRecipe(res.data.recipes));
   } catch (error) {
     console.log(error);
@@ -51,19 +63,36 @@ export const asyncAddRecipeActions = (recipe,userId) => async (dispatch, getStat
   }
 };
 
+export const asyncGetFavoritesActions = (userId) => async (dispatch) => {
+  try {
+    if (!userId) return;
+    const res = await axios.get(`/user/${userId}/favorites`);
+    dispatch(loadFavorites(res.data.favorites ?? []));
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 export const asyncAddToFavorite =
   ({ _id, favResult }) =>
   async (dispatch, getState) => {
-     dispatch(toggleFavoriteLocal({ id: _id, fav: favResult }));
+    const userId = getState()?.users?.data?.data?.user?._id;
+    if (!userId) {
+      toast.warn("Login required to save favorites");
+      return;
+    }
+
+    dispatch(toggleFavoriteLocal({ id: _id, fav: favResult }));
     try {
-
-      const res = await axios.patch(`/recipes/${_id}`, { fav: favResult });
-      dispatch(asyncGetRecipeActions());
+      await axios.post(`/recipes/${_id}/favorite`, {
+        userId,
+        favorite: favResult,
+      });
+      dispatch(asyncGetFavoritesActions(userId));
     } catch (error) {
-
       console.log(error);
-      
-    dispatch(toggleFavoriteLocal({ id: _id, fav: !favResult }));
+
+      dispatch(toggleFavoriteLocal({ id: _id, fav: !favResult }));
     }
   };
 
@@ -71,7 +100,13 @@ export const asyncUpdateRecipeHandler =
   ({ id, data }) =>
   async (dispatch, getState) => {
     try {
-      const res = await axios.patch(`/recipes/${id}`, data);
+      const userId = getState()?.users?.data?.data?.user?._id;
+      if (!userId) {
+        toast.warn("Login required to update recipes");
+        return;
+      }
+      const payload = { ...data, userId };
+      const res = await axios.patch(`/recipes/${id}`, payload);
       toast.success("recipe updated successfully!!");
       console.log(" recipe updated successfully", res);
       // console.log(res);
@@ -81,3 +116,19 @@ export const asyncUpdateRecipeHandler =
       toast.error("error while updating recipe in asyncUpdateRecipeHandler");
     }
   };
+
+export const asyncDeleteRecipeAction = (id) => async (dispatch, getState) => {
+  try {
+    const userId = getState()?.users?.data?.data?.user?._id;
+    if (!userId) {
+      toast.warn("Login required to delete recipes");
+      return;
+    }
+    await axios.delete(`/recipes/${id}`, { data: { userId } });
+    dispatch(deleteRecipe(id));
+    toast.success("recipe deleted successfully");
+  } catch (error) {
+    console.log(error);
+    toast.error("error while deleting recipe");
+  }
+};

--- a/frontend/src/store/actions/videosAction.jsx
+++ b/frontend/src/store/actions/videosAction.jsx
@@ -1,11 +1,13 @@
 import axios from "../../utils/axios";
 import { LoadVideos } from "../reducers/recipeSlice";
 
-export const asyncGetVideosActions=()=>async (dispatch ,getState)=> {
+export const asyncGetVideosActions = (filters = {}) => async (dispatch, getState) => {
     try {
-        const res=await axios.get('/videos');
-        dispatch(LoadVideos(res));
-        
+        const userId = getState()?.users?.data?.data?.user?._id;
+        const params = { ...filters };
+        if (userId) params.userId = userId;
+        const res = await axios.get("/videos", { params });
+        dispatch(LoadVideos(res.data?.videos ?? []));
 
     } catch (error) {
         console.log(error);

--- a/frontend/src/store/reducers/recipeSlice.jsx
+++ b/frontend/src/store/reducers/recipeSlice.jsx
@@ -21,8 +21,21 @@ const RecipeSlice = createSlice({
       localStorage.setItem("recipes", JSON.stringify(state.data));
     },
     deleteRecipe: (state, action) => {
-      state.data = state.data.filter(f, (index) => index !== action.payload); //ye mujhe id pe witch karna hai
-      localStorage.setItem("recipes", JSON.stringify(state.data));
+      const id = action.payload;
+      if (Array.isArray(state.data)) {
+        state.data = state.data.filter((item) => (item._id ?? item.id) !== id);
+        localStorage.setItem("recipes", JSON.stringify(state.data));
+      }
+      if (Array.isArray(state.MyRecipes)) {
+        state.MyRecipes = state.MyRecipes.filter(
+          (item) => (item._id ?? item.id) !== id
+        );
+      }
+      if (Array.isArray(state.Videos)) {
+        state.Videos = state.Videos.filter(
+          (item) => (item._id ?? item.id) !== id
+        );
+      }
     },
     loadRecipe: (state, action) => {
       state.data = action.payload ?? [];
@@ -47,13 +60,24 @@ const RecipeSlice = createSlice({
     },
     toggleFavoriteLocal: (state, action) => {
       const { id, fav } = action.payload;
-      const recipe = state.data.find((r) => r._id === id);
-      if (recipe) {
-        recipe.fav = fav;
+      const updateFav = (list) => {
+        const recipe = list?.find((r) => (r._id ?? r.id) === id);
+        if (recipe) {
+          recipe.fav = fav;
+        }
+      };
+      if (Array.isArray(state.data)) {
+        updateFav(state.data);
+      }
+      if (Array.isArray(state.MyRecipes)) {
+        updateFav(state.MyRecipes);
+      }
+      if (Array.isArray(state.Videos)) {
+        updateFav(state.Videos);
       }
     },
     LoadVideos:(state,action)=>{
-      state.Videos=action.payload;
+      state.Videos=action.payload ?? [];
     }
   },
 });

--- a/frontend/src/store/store.jsx
+++ b/frontend/src/store/store.jsx
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import recipeSlice from './reducers/RecipeSlice.jsx'
 import userSlice from  './reducers/UserSlice.jsx'
+import favoriteSlice from "./reducers/FavoriteSlice.jsx";
 export const store = configureStore({
-  reducer: { recipes: recipeSlice ,users: userSlice},
+  reducer: { recipes: recipeSlice, users: userSlice, favorites: favoriteSlice },
 });

--- a/frontend/src/utils/useInfiniteRecipe.jsx
+++ b/frontend/src/utils/useInfiniteRecipe.jsx
@@ -10,6 +10,7 @@ const useRegister = (initialCursor = null) => {
   const dispatch = useDispatch();
 
   const recipe = useSelector((state) => state.recipes.data) || [];
+  const userId = useSelector((state) => state?.users?.data?.data?.user?._id);
 
   const [cursor, setCursor] = useState(initialCursor);
   const abortRef = useRef(null);
@@ -28,6 +29,7 @@ const useRegister = (initialCursor = null) => {
     try {
       const params = { limit: 6 };
       if (cursor) params.after = cursor;
+      if (userId) params.userId = userId;
 
       const res = await axios.get("/recipes", { params, signal });
       const newItems = res.data?.recipes ?? [];


### PR DESCRIPTION
## Summary
- store favorites per user and expose favorites list
- enforce owner-only update/delete actions
- add recipe fields for time/difficulty/veg/trending and use them for video filters
- update mobile navbar toggle and profile favorites count

## Testing
- npm run lint (frontend) - passed